### PR TITLE
Extend DICOMweb assetstore support

### DIFF
--- a/import_tracker/web_client/main.js
+++ b/import_tracker/web_client/main.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import AssetstoreView from '@girder/core/views/body/AssetstoresView';
 import FilesystemImportView from '@girder/core/views/body/FilesystemImportView';
 import S3ImportView from '@girder/core/views/body/S3ImportView';
+import DICOMwebImportView from '@girder/dicomweb/views/DICOMwebImportView';
 
 import CollectionModel from '@girder/core/models/CollectionModel';
 import FolderModel from '@girder/core/models/FolderModel';
@@ -54,6 +55,11 @@ wrap(S3ImportView, 'render', function (render) {
 
     this.$('.form-group').last().after(excludeExistingInput({ type: 's3' }));
 });
+wrap(DICOMwebImportView, 'render', function (render) {
+    render.call(this);
+
+    this.$('.form-group').last().after(excludeExistingInput({ type: 'dwas' }));
+});
 
 const setBrowserRoot = (view, type) => {
     const browserWidget = view._browserWidgetView;
@@ -97,13 +103,17 @@ wrap(S3ImportView, '_openBrowser', function (_openBrowser) {
     setBrowserRoot(this, 's3');
     _openBrowser.call(this);
 });
+wrap(DICOMwebImportView, '_openBrowser', function (_openBrowser) {
+    setBrowserRoot(this, 'dwas');
+    _openBrowser.call(this);
+});
 
 // We can't just wrap the submit events, as we need to modify what is passed to
 // the assetstore import method
 FilesystemImportView.prototype.events['submit .g-filesystem-import-form'] = function (e) {
     e.preventDefault();
 
-    var destId = this.$('#g-filesystem-import-dest-id').val().trim().split(/\s/)[0],
+    let destId = this.$('#g-filesystem-import-dest-id').val().trim().split(/\s/)[0],
         destType = this.$('#g-filesystem-import-dest-type').val(),
         foldersAsItems = this.$('#g-filesystem-import-leaf-items').val(),
         excludeExisting = this.$('#g-filesystem-import-exclude-existing').val();
@@ -126,7 +136,7 @@ FilesystemImportView.prototype.events['submit .g-filesystem-import-form'] = func
 S3ImportView.prototype.events['submit .g-s3-import-form'] = function (e) {
     e.preventDefault();
 
-    var destId = this.$('#g-s3-import-dest-id').val().trim().split(/\s/)[0],
+    let destId = this.$('#g-s3-import-dest-id').val().trim().split(/\s/)[0],
         destType = this.$('#g-s3-import-dest-type').val(),
         excludeExisting = this.$('#g-s3-import-exclude-existing').val();
 
@@ -141,6 +151,32 @@ S3ImportView.prototype.events['submit .g-s3-import-form'] = function (e) {
         destinationId: destId,
         destinationType: destType,
         excludeExisting: excludeExisting,
+        progress: true
+    });
+};
+DICOMwebImportView.prototype.events['submit .g-dwas-import-form'] = function (e) {
+    e.preventDefault();
+
+    let destId = this.$('#g-dwas-import-dest-id').val().trim().split(/\s/)[0],
+        destType = this.$('#g-dwas-import-dest-type').val(),
+        excludeExisting = this.$('#g-dwas-import-exclude-existing').val(),
+        filters = this.$('#g-dwas-import-filters').val().trim(),
+        limit = this.$('#g-dwas-import-limit').val().trim();
+
+    this.$('.g-validation-failed-message').empty();
+
+    this.$('.g-submit-dwas-import').addClass('disabled');
+    this.model.off().on('g:imported', function () {
+        router.navigate(destType + '/' + destId, { trigger: true });
+    }, this).on('g:error', function (err) {
+        this.$('.g-submit-dwas-import').removeClass('disabled');
+        this.$('.g-validation-failed-message').html(err.responseJSON.message);
+    }, this).dicomwebImport({
+        destinationId: destId,
+        destinationType: destType,
+        limit,
+        filters,
+        excludeExisting,
         progress: true
     });
 };

--- a/import_tracker/web_client/package.json
+++ b/import_tracker/web_client/package.json
@@ -13,7 +13,8 @@
         "name": "import_tracker",
         "main": "./main.js",
         "dependencies": [
-            "jobs"
+            "jobs",
+            "dicomweb"
         ]
     },
     "scripts": {


### PR DESCRIPTION
This PR makes the `dicomweb` plugin an explicit dependency of `import_tracker` to enable access to DICOMweb assetstore JS elements, which have been wrapped for parity with the other supported assetstores.