### PR TITLE
Remove extraneous filtering for unique import edits in importList view

### DIFF
--- a/import_tracker/rest.py
+++ b/import_tracker/rest.py
@@ -64,7 +64,8 @@ def getImports(query=None, user=None, unique=False, limit=None, offset=None, sor
                 },
                 '_count': {'$sum': 1},
                 'started': {'$first': '$started'},
-                'ended': {'$first': '$ended'}
+                'ended': {'$first': '$ended'},
+                'first_id': {'$first': '$_id'},
             }},
             {'$project': {
                 'assetstoreId': '$_id.assetstoreId',
@@ -72,7 +73,7 @@ def getImports(query=None, user=None, unique=False, limit=None, offset=None, sor
                 '_count': '$_count',
                 'started': '$started',
                 'ended': '$ended',
-                '_id': None
+                '_id': '$first_id',
             }},
             {'$sort': {k: v for k, v in sort}},
             {'$skip': offset or 0},

--- a/import_tracker/web_client/views/importList.js
+++ b/import_tracker/web_client/views/importList.js
@@ -61,24 +61,7 @@ var importList = View.extend({
 
             const assetstoreId = importEvent.assetstoreId;
             const importId = importEvent._id; // Only individual imports have an _id
-            if (importId) {
-                navigate(assetstoreId, importId);
-                return;
-            }
-
-            // If the importEvent aggregated 'unique' imports, we need to find a matching importId
-            restRequest({
-                url: `assetstore/${assetstoreId}/imports`,
-                data: { unique: false }
-            }).done((results) => {
-                const importId = results.filter((i) =>
-                    i.params.importPath === importEvent.params.importPath &&
-                    i.params.destinationId === importEvent.params.destinationId &&
-                    i.params.destinationType === importEvent.params.destinationType
-                )[0]._id;
-
-                navigate(assetstoreId, importId);
-            });
+            navigate(assetstoreId, importId);
         }
     },
 


### PR DESCRIPTION
Changed the mongo query for `assetstore/{id}/imports` `{unique: true}` endpoint to store the `_id` of the first element in unique grouping; which avoids the manual filter-based search I was previously doing to find `_id`.
This `_id` is needed as a reference for re-import-editing unique imports as we need a reference to an individual import record to copy.