### PR TITLE
Add support for generic assetstores

### DIFF
--- a/import_tracker/web_client/main.js
+++ b/import_tracker/web_client/main.js
@@ -120,7 +120,7 @@ const importSubmit = (view, type) => {
     view.$('.g-validation-failed-message').empty();
     view.$(`.g-submit-${type}-import`).addClass('disabled');
 
-    let model = type === 'dwas' ? view.model : view.assetstore;
+    let model = view.assetstore;
     model = model.off().on('g:imported', function () {
         router.navigate(destinationType + '/' + destinationId, { trigger: true });
     }, view).on('g:error', function (err) {
@@ -128,11 +128,7 @@ const importSubmit = (view, type) => {
         view.$('.g-validation-failed-message').html(err.responseJSON.message);
     }, view);
 
-    if (type === 'dwas') {
-        model.dicomwebImport(importParams);
-    } else {
-        model.import(importParams);
-    }
+    model.import(importParams);
 };
 
 FilesystemImportView.prototype.events['submit .g-filesystem-import-form'] = function (e) {

--- a/import_tracker/web_client/main.js
+++ b/import_tracker/web_client/main.js
@@ -57,9 +57,9 @@ wrap(S3ImportView, 'render', function (render) {
 
 const setBrowserRoot = (view, type) => {
     const browserWidget = view._browserWidgetView;
-    const destType = view.$(`#g-${type}-import-dest-type`).val();
-    const destId = view.$(`#g-${type}-import-dest-id`).val();
-    const resourceId = destId.trim().split(/\s/)[0];
+    const destinationType = view.$(`#g-${type}-import-dest-type`).val();
+    const destinationId = view.$(`#g-${type}-import-dest-id`).val();
+    const resourceId = destinationId.trim().split(/\s/)[0];
 
     const models = {
         collection: CollectionModel,
@@ -67,8 +67,8 @@ const setBrowserRoot = (view, type) => {
         user: UserModel
     };
 
-    if (resourceId && destType in models) {
-        const model = new models[destType]({ _id: resourceId });
+    if (resourceId && destinationType in models) {
+        const model = new models[destinationType]({ _id: resourceId });
 
         model.once('g:fetched', () => {
             if (!browserWidget.root || browserWidget.root.id !== model.id) {
@@ -79,7 +79,7 @@ const setBrowserRoot = (view, type) => {
             if (err.status === 400) {
                 events.trigger('g:alert', {
                     icon: 'cancel',
-                    text: `No ${destType.toUpperCase()} with ID ${resourceId} found.`,
+                    text: `No ${destinationType.toUpperCase()} with ID ${resourceId} found.`,
                     type: 'danger',
                     timeout: 4000
                 });
@@ -100,49 +100,48 @@ wrap(S3ImportView, '_openBrowser', function (_openBrowser) {
 
 // We can't just wrap the submit events, as we need to modify what is passed to
 // the assetstore import method
+const importSubmit = (view, type) => {
+    const destinationId = view.$(`#g-${type}-import-dest-id`).val().trim().split(/\s/)[0];
+    const destinationType = view.$(`#g-${type}-import-dest-type`).val();
+    const excludeExisting = view.$(`#g-${type}-import-exclude-existing`).val();
+
+    const importParams = { destinationId, destinationType, excludeExisting, progress: true };
+
+    if (type === 'filesystem') {
+        importParams.leafFoldersAsItems = view.$(`#g-${type}-import-leaf-items`).val();
+    }
+    if (type === 'dwas') {
+        importParams.filters = view.$(`#g-${type}-import-filters`).val().trim();
+        importParams.limit = view.$(`#g-${type}-import-limit`).val().trim();
+    } else {
+        importParams.importPath = view.$(`#g-${type}-import-path`).val().trim();
+    }
+
+    view.$('.g-validation-failed-message').empty();
+    view.$(`.g-submit-${type}-import`).addClass('disabled');
+
+    let model = type === 'dwas' ? view.model : view.assetstore;
+    model = model.off().on('g:imported', function () {
+        router.navigate(destinationType + '/' + destinationId, { trigger: true });
+    }, view).on('g:error', function (err) {
+        view.$(`.g-submit-${type}-import`).removeClass('disabled');
+        view.$('.g-validation-failed-message').html(err.responseJSON.message);
+    }, view);
+
+    if (type === 'dwas') {
+        model.dicomwebImport(importParams);
+    } else {
+        model.import(importParams);
+    }
+};
+
 FilesystemImportView.prototype.events['submit .g-filesystem-import-form'] = function (e) {
     e.preventDefault();
-
-    var destId = this.$('#g-filesystem-import-dest-id').val().trim().split(/\s/)[0],
-        destType = this.$('#g-filesystem-import-dest-type').val(),
-        foldersAsItems = this.$('#g-filesystem-import-leaf-items').val(),
-        excludeExisting = this.$('#g-filesystem-import-exclude-existing').val();
-
-    this.$('.g-validation-failed-message').empty();
-
-    this.assetstore.off('g:imported').on('g:imported', function () {
-        router.navigate(destType + '/' + destId, { trigger: true });
-    }, this).on('g:error', function (resp) {
-        this.$('.g-validation-failed-message').text(resp.responseJSON.message);
-    }, this).import({
-        importPath: this.$('#g-filesystem-import-path').val().trim(),
-        leafFoldersAsItems: foldersAsItems,
-        destinationId: destId,
-        destinationType: destType,
-        excludeExisting: excludeExisting,
-        progress: true
-    });
+    importSubmit(this, 'filesystem');
 };
 S3ImportView.prototype.events['submit .g-s3-import-form'] = function (e) {
     e.preventDefault();
-
-    var destId = this.$('#g-s3-import-dest-id').val().trim().split(/\s/)[0],
-        destType = this.$('#g-s3-import-dest-type').val(),
-        excludeExisting = this.$('#g-s3-import-exclude-existing').val();
-
-    this.$('.g-validation-failed-message').empty();
-
-    this.assetstore.off('g:imported').on('g:imported', function () {
-        router.navigate(destType + '/' + destId, { trigger: true });
-    }, this).on('g:error', function (resp) {
-        this.$('.g-validation-failed-message').text(resp.responseJSON.message);
-    }, this).import({
-        importPath: this.$('#g-s3-import-path').val().trim(),
-        destinationId: destId,
-        destinationType: destType,
-        excludeExisting: excludeExisting,
-        progress: true
-    });
+    importSubmit(this, 's3');
 };
 
 // Setup router to assetstore imports view

--- a/import_tracker/web_client/views/importList.js
+++ b/import_tracker/web_client/views/importList.js
@@ -5,7 +5,7 @@ import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
 import Collection from '@girder/core/collections/Collection';
 
 import AssetstoreModel from '@girder/core/models/AssetstoreModel';
-import { AssetstoreType, SORT_DESC } from '@girder/core/constants';
+import { SORT_DESC } from '@girder/core/constants';
 import View from '@girder/core/views/View';
 import router from '@girder/core/router';
 import { restRequest } from '@girder/core/rest';
@@ -34,11 +34,7 @@ var importList = View.extend({
             }, this);
 
             assetstore.once('g:fetched', () => {
-                if (assetstore.get('type') === AssetstoreType.DICOMWEB) {
-                    assetstore.dicomwebImport(importEvent.get('params'));
-                } else {
-                    assetstore.import(importEvent.get('params'));
-                }
+                assetstore.import(importEvent.get('params'));
             }).fetch();
         },
         'click .re-import-edit-btn': function (e) {
@@ -52,13 +48,7 @@ var importList = View.extend({
             const navigate = (assetstoreId, importId) => {
                 const assetstore = new AssetstoreModel({ _id: assetstoreId });
                 assetstore.once('g:fetched', () => {
-                    if (assetstore.get('type') === AssetstoreType.DICOMWEB) {
-                        // Avoid adding previous import data for DICOMweb imports by navigating to blank import
-                        // TODO: Add DICOMweb-specific re-import view
-                        router.navigate(`dicomweb_assetstore/${assetstoreId}/import`, { trigger: true });
-                    } else {
-                        router.navigate(`assetstore/${assetstoreId}/re-import/${importId}`, { trigger: true });
-                    }
+                    router.navigate(`assetstore/${assetstoreId}/re-import/${importId}`, { trigger: true });
                 }).fetch();
             };
 

--- a/import_tracker/web_client/views/reImport.js
+++ b/import_tracker/web_client/views/reImport.js
@@ -1,11 +1,17 @@
 import AssetstoreModel from '@girder/core/models/AssetstoreModel';
 import View from '@girder/core/views/View';
+import { AssetstoreType } from '@girder/core/constants';
 
 import router from '@girder/core/router';
 import events from '@girder/core/events';
 import { restRequest } from '@girder/core/rest';
 
-const goBack = (assetstoreId) => {
+const goBack = (assetstoreId, message) => {
+    events.trigger('g:alert', {
+        icon: 'cancel',
+        text: `Could not re-import: ${message}`,
+        type: 'danger'
+    });
     router.navigate(
         `assetstore/${assetstoreId}/import`,
         { trigger: true, replace: true }
@@ -23,7 +29,7 @@ var reImportView = View.extend({
             error: null
         }).done((assetstoreImport) => {
             if (!assetstoreImport) {
-                goBack(this.assetstoreId);
+                goBack(this.assetstoreId, `Unable to find import ${importId}`);
                 return;
             }
 
@@ -32,16 +38,20 @@ var reImportView = View.extend({
             // collect assetstore type info and render
             const assetstore = new AssetstoreModel({ _id: assetstoreId });
             assetstore.once('g:fetched', () => {
-                this.type = assetstore.get('type') === 0 ? 'filesystem' : 's3';
+                const assetstoreType = assetstore.get('type');
+                if (assetstoreType === AssetstoreType.FILESYSTEM) {
+                    this.type = 'filesystem';
+                } else if (assetstoreType === AssetstoreType.S3) {
+                    this.type = 's3';
+                } else if (assetstoreType === AssetstoreType.DICOMWEB) {
+                    this.type = 'dwas';
+                } else {
+                    goBack(this.assetstoreId, `Unsupported assetstore type '${assetstoreType}'`);
+                }
                 this.render();
             }).fetch();
         }).fail(() => {
-            events.trigger('g:alert', {
-                icon: 'cancel',
-                text: 'Unable to fetch base import information. Redirected to empty import page',
-                type: 'danger'
-            });
-            goBack(this.assetstoreId);
+            goBack(this.assetstoreId, 'Unable to fetch base import information');
         });
     },
 
@@ -56,6 +66,11 @@ var reImportView = View.extend({
         this.$(`#g-${this.type}-import-dest-id`).val(destId);
         this.$(`#g-${this.type}-import-leaf-items`).val(params.leafFoldersAsItems);
         this.$(`#g-${this.type}-import-exclude-existing`).val(excludeExisting);
+
+        if (this.type === 'dwas') {
+            this.$(`#g-${this.type}-import-filters`).val(params.filters);
+            this.$(`#g-${this.type}-import-limit`).val(params.limit);
+        }
 
         restRequest({
             url: `resource/${destId}/path`,

--- a/import_tracker/web_client/views/reImport.js
+++ b/import_tracker/web_client/views/reImport.js
@@ -45,6 +45,8 @@ var reImportView = View.extend({
                     this.type = 's3';
                 } else if (assetstoreType === AssetstoreType.DICOMWEB) {
                     this.type = 'dwas';
+                } else if (assetstoreType === AssetstoreType.GIRDER) {
+                    this.type = 'gas';
                 } else {
                     goBack(this.assetstoreId, `Unsupported assetstore type '${assetstoreType}'`);
                 }


### PR DESCRIPTION
- Change `importDataWrapper()` to allow for generic parameters, per https://github.com/girder/girder/pull/3527
- Removes outdated DICOMweb-specific code
- Adds support for Girder Assetstore re-import pages